### PR TITLE
Fixes for Python 3.5, 3.6, 3.10

### DIFF
--- a/cdist/exec/util.py
+++ b/cdist/exec/util.py
@@ -25,7 +25,6 @@ from tempfile import TemporaryFile
 from collections import OrderedDict
 
 import cdist
-import cdist.configuration
 
 
 # IMPORTANT:
@@ -207,6 +206,7 @@ def resolve_conf_dirs(configuration, add_conf_dirs):
 
 
 def resolve_conf_dirs_from_config_and_args(args):
+    import cdist.configuration
     cfg = cdist.configuration.Configuration(args)
     configuration = cfg.get_config(section='GLOBAL')
     return resolve_conf_dirs(configuration, args.conf_dir)

--- a/cdist/test/explorer/__init__.py
+++ b/cdist/test/explorer/__init__.py
@@ -92,7 +92,7 @@ class ExplorerClassTestCase(test.CdistTestCase):
                          sorted(os.listdir(destination)))
 
     def test_run_global_explorer(self):
-        """Checkt that running ONE global explorer works"""
+        """Check that running ONE global explorer works"""
         self.explorer.transfer_global_explorers()
         output = self.explorer.run_global_explorer('global')
         self.assertEqual(output, 'global\n')

--- a/cdist/util/fsproperty.py
+++ b/cdist/util/fsproperty.py
@@ -20,9 +20,13 @@
 #
 
 import os
-import collections
 
 import cdist
+
+try:
+    from collections.abc import (MutableMapping, MutableSequence)
+except ImportError:
+    from collections import (MutableMapping, MutableSequence)
 
 
 class AbsolutePathRequiredError(cdist.Error):
@@ -33,7 +37,7 @@ class AbsolutePathRequiredError(cdist.Error):
         return 'Absolute path required, got: {}'.format(self.path)
 
 
-class FileList(collections.MutableSequence):
+class FileList(MutableSequence):
     """A list that stores it's state in a file.
 
     """
@@ -102,7 +106,7 @@ class FileList(collections.MutableSequence):
         self.__write(lines)
 
 
-class DirectoryDict(collections.MutableMapping):
+class DirectoryDict(MutableMapping):
     """A dict that stores it's items as files in a directory.
 
     """


### PR DESCRIPTION
This PR fixes 
* a cyclic import in `cdist.exec.util` that broke the tests on Python 3.5, 3.6 on Linux (interestingly not on macOS).
* imports ABCs from `collections.abc` if available to make cdist work with Python 3.10.

All tests are now green.