### PR TITLE
[cdist_type] Only strip trailing new lines from parameter defaults

### DIFF
--- a/cdist/core/cdist_type.py
+++ b/cdist/core/cdist_type.py
@@ -268,7 +268,7 @@ class CdistType:
                 for name in cdist.core.listdir(defaults_dir):
                     try:
                         with open(os.path.join(defaults_dir, name)) as fd:
-                            defaults[name] = fd.read().strip()
+                            defaults[name] = fd.read().rstrip("\n")
                     except EnvironmentError:
                         pass  # Swallow errors raised by open() or read()
             except EnvironmentError:

--- a/docs/changelog
+++ b/docs/changelog
@@ -12,6 +12,7 @@ next:
 	* Type __debconf_set_selections: Fix bug where --file was unsupported (Evilham)
 	* Types __letsencrypt_cert, __grafana_dashboard: Improve bullseye support (Evilham)
 	* Type __package_apt: Mark already installed packages as manual (Dennis Camera)
+	* Core: Strip only trailing new lines from parameter defaults, instead of leading and trailing whitespace (Dennis Camera)
 
 6.9.8: 2021-08-24
 	* Type __rsync: Rewrite (Ander Punnar)


### PR DESCRIPTION
Fixes [#324](https://code.ungleich.ch/ungleich-public/cdist/issues/324).

NB: this patch strips all sequences of new line characters from the end of the parameter default.
I couldn't come up with a use case for trailing empty lines, but if someone can, I'd modify the code so that only the last new line is stripped.

Maybe carriage returns should also be stripped, but I guess that stripping fewer characters is potentially less frustrating for users, because removing unwanted characters from parameter defaults is easier than to patch cdist to not strip characters they actually wanted.