### PR TITLE
Add start up Python version checks

### DIFF
--- a/bin/cdist
+++ b/bin/cdist
@@ -26,6 +26,8 @@ import logging
 import os
 import sys
 
+log = logging.getLogger("cdist")
+
 # See if this file's parent is cdist module
 # and if so add it to module search path.
 cdist_dir = os.path.realpath(
@@ -43,6 +45,46 @@ import cdist.config     # noqa 402
 import cdist.install    # noqa 402
 import cdist.shell      # noqa 402
 import cdist.inventory  # noqa 402
+
+
+def _check_python_version():
+    import textwrap
+    silence_hint = textwrap.dedent("""\
+    You can silence this warning by
+    - setting the environment variable CDIST_CHECK_PYTHON_VERSION=no, or
+    - by adding check_python_version = no to the cdist.cfg.
+    """)
+
+    if sys.version_info < cdist.MIN_RECOMMENDED_PYTHON_VERSION:
+        log.warning(
+            "It is not recommended to run cdist on Python versions older than "
+            "%s. You are using %s.\n"
+            "While it should still work, you may want to try to upgrade to a "
+            "newer version of Python.\n\n%s",
+            ".".join(map(str, cdist.MIN_RECOMMENDED_PYTHON_VERSION)),
+            sys.version.split()[0],
+            silence_hint)
+
+    # NOTE: test for releaselevel before MAX_TESTED_PYTHON_VERSION because
+    #       pre-release versions should never be in MAX_TESTED_PYTHON_VERSION.
+    elif sys.version_info.releaselevel != "final":
+        log.warning(
+            "You are running cdist on a pre-release version of Python (%s). "
+            "You may experience bugs.\n\n%s",
+            sys.version.split()[0],
+            silence_hint)
+
+    # NOTE: limit the precision of sys.version_info to the precision of
+    #       cdist.MAX_TESTED_PYTHON_VERSION to not produce false-positives when
+    #       cdist is run on e.g. (3, 10, 2) and MAX_TESTED_PYTHON_VERSION is
+    #       (3, 10)
+    elif sys.version_info[:len(cdist.MAX_TESTED_PYTHON_VERSION)] \
+            > cdist.MAX_TESTED_PYTHON_VERSION:
+        log.warning(
+            "cdist has not been tested on Python %s. Please check if there is "
+            "a newer version of cdist available.\n\n%s",
+            sys.version.split()[0],
+            silence_hint)
 
 
 def _commandline():
@@ -69,15 +111,19 @@ def _commandline():
         parser['main'].print_help()
         sys.exit(0)
 
+    if cfg.get_config(section="GLOBAL").get("check_python_version", True):
+        _check_python_version()
+
     args.func(args)
 
 
 if __name__ == "__main__":
-    if sys.version_info[:3] < cdist.MIN_SUPPORTED_PYTHON_VERSION:
-        print(
-            'Python >= {} is required on the source host.'.format(
-                ".".join(map(str, cdist.MIN_SUPPORTED_PYTHON_VERSION))),
-            file=sys.stderr)
+    if sys.version_info < cdist.MIN_SUPPORTED_PYTHON_VERSION:
+        log.error(
+            "Python >= %s is required on the source host. "
+            "You are using %s.",
+            ".".join(map(str, cdist.MIN_SUPPORTED_PYTHON_VERSION)),
+            sys.version.split()[0])
         sys.exit(1)
 
     try:
@@ -88,7 +134,7 @@ if __name__ == "__main__":
             _commandline()
         sys.exit(0)
     except cdist.Error as e:
-        logging.getLogger("cdist").error(e)
+        log.error(e)
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(2)

--- a/bin/cdist
+++ b/bin/cdist
@@ -3,6 +3,7 @@
 #
 # 2010-2016 Nico Schottelius (nico-cdist at schottelius.org)
 # 2016 Darko Poljak (darko.poljak at gmail.com)
+# 2021 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -44,7 +45,7 @@ import cdist.shell      # noqa 402
 import cdist.inventory  # noqa 402
 
 
-def commandline():
+def _commandline():
     """Parse command line"""
 
     # preos subcommand hack
@@ -79,25 +80,15 @@ if __name__ == "__main__":
             file=sys.stderr)
         sys.exit(1)
 
-    exit_code = 0
-
     try:
-        import re
-        import os
-
-        if re.match("__", os.path.basename(sys.argv[0])):
+        if os.path.basename(sys.argv[0])[:2] == "__":
             import cdist.emulator
-            emulator = cdist.emulator.Emulator(sys.argv)
-            emulator.run()
+            cdist.emulator.Emulator(sys.argv).run()
         else:
-            commandline()
-
-    except KeyboardInterrupt:
-        exit_code = 2
-
+            _commandline()
+        sys.exit(0)
     except cdist.Error as e:
-        log = logging.getLogger("cdist")
-        log.error(e)
-        exit_code = 1
-
-    sys.exit(exit_code)
+        logging.getLogger("cdist").error(e)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(2)

--- a/cdist/__init__.py
+++ b/cdist/__init__.py
@@ -64,7 +64,14 @@ REMOTE_EXEC = "ssh -o User=root"
 REMOTE_CMDS_CLEANUP_PATTERN = "ssh -o User=root -O exit -S {}"
 
 
+# minimum Python version required to run cdist.
+# cdist will refuse to run on lower versions.
 MIN_SUPPORTED_PYTHON_VERSION = (3, 2)
+# minimum recommended Python version. cdist will warn on lower versions.
+# usually the oldest version supported upstream.
+MIN_RECOMMENDED_PYTHON_VERSION = (3, 7)
+# maximum (currently) tested Python version.
+MAX_TESTED_PYTHON_VERSION = (3, 10)
 
 
 class Error(Exception):

--- a/cdist/configuration.py
+++ b/cdist/configuration.py
@@ -333,6 +333,7 @@ class Configuration(metaclass=Singleton):
             'save_output_streams': BooleanOption('save_output_streams',
                                                  default_overrides=False),
             'timestamp': BooleanOption('timestamp'),
+            'check_python_version': BooleanOption('check_python_version'),
         },
     }
 
@@ -347,6 +348,7 @@ class Configuration(metaclass=Singleton):
         'CDIST_CACHE_PATH_PATTERN': 'cache_path_pattern',
         'CDIST_COLORED_OUTPUT': 'colored_output',
         '__cdist_log_level': 'verbosity',
+        'CDIST_CHECK_PYTHON_VERSION': 'check_python_version',
     }
     ENV_VAR_BOOLEAN_OPTIONS = ('CDIST_BETA', )
     ENV_VAR_OPTIONS = {

--- a/docs/changelog
+++ b/docs/changelog
@@ -13,6 +13,7 @@ next:
 	* Types __letsencrypt_cert, __grafana_dashboard: Improve bullseye support (Evilham)
 	* Type __package_apt: Mark already installed packages as manual (Dennis Camera)
 	* Core: Strip only trailing new lines from parameter defaults, instead of leading and trailing whitespace (Dennis Camera)
+	* Core: Implement more sophisticated Python version checks (Dennis Camera)
 
 6.9.8: 2021-08-24
 	* Type __rsync: Rewrite (Ander Punnar)


### PR DESCRIPTION
This PR adds start up version checks for too old and too new versions.
Due to the way that logging initialisation and argument parsing works in cdist the "optional" checks are only executed when a cdist sub-command is launched (e.g. `cdist config` instead of just `cdist`).

The different limits can be configured (as has been) in `cdist/__init__.py`:
* `MIN_SUPPORTED_PYTHON_VERSION`: cdist will refuse to start when run with a Python interpreter lower than this.
* `MIN_RECOMMENDED_PYTHON_VERSION`: usually the oldest Python 3 release still supported upstream. cdist will print a warning when run with a Python interpreter lower than this, but still work.
* `MAX_TESTED_PYTHON_VERSION`: the newest version of Python we have in CI. cdist will print a warning when run with a Python interpreter higher than this.
* cdist will also print a warning when cdist is run with a pre-release version of Python.