### PR TITLE
Only run pycodestyle on cdist source

### DIFF
--- a/bin/cdist-build-helper
+++ b/bin/cdist-build-helper
@@ -405,7 +405,7 @@ eof
     ;;
 
     pycodestyle|pep8)
-        pycodestyle "${basedir}" "${basedir}/bin/cdist"
+        pycodestyle "${basedir}/cdist/" "${basedir}/bin/"
     ;;
 
     check-pycodestyle)


### PR DESCRIPTION
If you have a virtualenv in the source tree pycodestyle would've checked the
whole virtualenv, which is not what you want.
This patch fixes that by only scanning the `bin` and `cdist` directories.