### PR TITLE
Fixes in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ version_file = os.path.join('cdist', 'version.py')
 # If we have build-helper we could be a git repo.
 if os.path.exists(build_helper):
     # Try to generate version.py.
-    rv = subprocess.run([build_helper, 'version', ])
-    if rv.returncode != 0:
+    rc = subprocess.call([build_helper, 'version'], shell=False)
+    if rc != 0:
         raise DistutilsError("Failed to generate {}".format(version_file))
 else:
     # Otherwise, version.py should be present.

--- a/setup.py
+++ b/setup.py
@@ -27,21 +27,20 @@ import cdist  # noqa
 def data_finder(data_dir):
     entries = []
     for name in os.listdir(data_dir):
-
         # Skip .gitignore files
         if name == ".gitignore":
             continue
 
         # Skip vim swp files
-        swpfile = re.search(r'^\..*\.swp$', name)
-        if swpfile:
+        if re.search(r'^\..*\.swp$', name):
+            continue
+
+        # Skip Emacs backups files
+        if re.search(r'(^\.?#|~$)', name):
             continue
 
         entry = os.path.join(data_dir, name)
-        if os.path.isdir(entry):
-            entries.extend(data_finder(entry))
-        else:
-            entries.append(entry)
+        entries += data_finder(entry) if os.path.isdir(entry) else [entry]
 
     return entries
 


### PR DESCRIPTION
This PR fixes the `setup.py` file for Python < 3.5 and adds Emacs backup files to the ignore list in `data_finder` like Vim swp files.