### PR TITLE
Replace `glob.glob1()` with custom listdir function

### DIFF
--- a/skonfig/autil.py
+++ b/skonfig/autil.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # 2017 Darko Poljak (darko.poljak at gmail.com)
-# 2023 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2023,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig.
 #
@@ -23,6 +23,8 @@ import glob
 import os
 import tarfile
 import tempfile
+
+from skonfig.util import ilistdir
 
 
 class ArchivingMode:
@@ -104,9 +106,13 @@ FILES_LIMIT = 1
 
 
 def tar(source, mode=TGZ):
-    files = glob.glob1(source, '*')
-    fcnt = len(files)
-    if fcnt <= FILES_LIMIT:
+    fcnt = 0
+    for f in ilistdir(source, recursive=True):
+        fcnt += 1
+        if fcnt >= FILES_LIMIT:
+            break
+    else:
+        # not enough files for archiving
         return (None, fcnt)
 
     tarmode = "w:%s" % (mode.tarmode)
@@ -118,7 +124,7 @@ def tar(source, mode=TGZ):
         format=tarfile.USTAR_FORMAT
     ) as tar:
         if os.path.isdir(source):
-            for f in files:
+            for f in ilistdir(source, recursive=False):
                 tar.add(os.path.join(source, f), arcname=f)
         else:
             tar.add(source)

--- a/skonfig/core/explorer.py
+++ b/skonfig/core/explorer.py
@@ -29,7 +29,7 @@ import skonfig
 import skonfig.logging
 
 from skonfig.mputil import mp_pool_run
-from skonfig.util import shquot
+from skonfig.util import (listdir, shquot)
 
 """
 common:
@@ -101,7 +101,7 @@ class Explorer:
 
     def list_global_explorer_names(self):
         """Return a list of global explorer names."""
-        return glob.glob1(self.local.global_explorer_path, '*')
+        return listdir(self.local.global_explorer_path, recursive=False)
 
     def run_global_explorers(self, out_path):
         """Run global explorers and save output to files in the given
@@ -179,7 +179,7 @@ class Explorer:
         """Return a list of explorer names for the given type."""
         source = os.path.join(self.local.type_path, cdist_type.explorer_path)
         try:
-            return glob.glob1(source, '*')
+            return listdir(source, recursive=False)
         except EnvironmentError:
             return []
 

--- a/skonfig/exec/remote.py
+++ b/skonfig/exec/remote.py
@@ -29,7 +29,7 @@ import skonfig
 import skonfig.logging
 
 from skonfig.exec import util
-from skonfig.util import (ipaddr, shquot)
+from skonfig.util import (ilistdir, ipaddr, shquot)
 
 
 def _wrap_addr(addr):
@@ -206,7 +206,7 @@ class Remote:
             self._transfer_file(source, destination, umask=umask)
 
     def _transfer_dir(self, source, destination, umask=None):
-        for path in glob.glob1(source, "*"):
+        for path in ilistdir(source, recursive=False):
             src_path = os.path.join(source, path)
             dst_path = os.path.join(destination, path)
             if os.path.isdir(src_path):

--- a/skonfig/util/__init__.py
+++ b/skonfig/util/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # 2012 Nico Schottelius (nico-cdist at schottelius.org)
+# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig.
 #
@@ -19,6 +20,7 @@
 #
 
 import hashlib
+import os
 
 
 def str_hash(s):
@@ -27,3 +29,28 @@ def str_hash(s):
         return hashlib.md5(s.encode('utf-8')).hexdigest()
     else:
         raise Error("Param should be string")
+
+
+def ilistdir(path, recursive=False):
+    """Return a directory listing of path as an interator.
+
+    Hidden files and save files are ignored.
+    """
+    for f in os.listdir(path):
+        if "." == f[0] or "~" == f[-1]:
+            continue
+
+        if recursive:
+            full_path = os.path.join(path, f)
+            if os.path.isdir(full_path):
+                subprefix = os.path.join(f, "")
+                for x in ilistdir(full_path, recursive=True):
+                    yield (subprefix + x)
+                continue
+
+        yield f
+
+
+def listdir(path, recursive=False):
+    """Return a directory listing of path as a list."""
+    return list(ilistdir(path, recursive=recursive))

--- a/tests/explorer/__init__.py
+++ b/tests/explorer/__init__.py
@@ -36,6 +36,7 @@ from skonfig import core
 from skonfig.core import explorer
 from skonfig.exec import (local, remote)
 
+ilistdir = skonfig.util.ilistdir
 
 my_dir = os.path.abspath(os.path.dirname(__file__))
 fixtures = os.path.join(my_dir, 'fixtures')
@@ -92,8 +93,8 @@ class ExplorerClassTestCase(test.SkonfigTestCase):
         source = self.local.global_explorer_path
         destination = self.remote.global_explorer_path
         self.assertEqual(
-            sorted(glob.glob1(source, "*")),
-            sorted(glob.glob1(destination, "*")))
+            sorted(ilistdir(source, recursive=False)),
+            sorted(ilistdir(destination, recursive=False)))
 
         self.assertFalse(
             os.path.exists(os.path.join(destination, ".hidden")))
@@ -129,8 +130,8 @@ class ExplorerClassTestCase(test.SkonfigTestCase):
         destination = os.path.join(self.remote.type_path,
                                    cdist_type.explorer_path)
         self.assertEqual(
-            sorted(glob.glob1(source, "*")),
-            sorted(glob.glob1(destination, "*")))
+            sorted(ilistdir(source, recursive=False)),
+            sorted(ilistdir(destination, recursive=False)))
 
     def test_transfer_type_explorers_only_once(self):
         cdist_type = core.CdistType(self.local.type_path, '__test_type')
@@ -140,8 +141,8 @@ class ExplorerClassTestCase(test.SkonfigTestCase):
         destination = os.path.join(self.remote.type_path,
                                    cdist_type.explorer_path)
         self.assertEqual(
-            sorted(glob.glob1(source, "*")),
-            sorted(glob.glob1(destination, "*")))
+            sorted(ilistdir(source, recursive=False)),
+            sorted(ilistdir(destination, recursive=False)))
         # nuke destination folder content, but recreate directory
         shutil.rmtree(destination)
         os.makedirs(destination)
@@ -165,8 +166,8 @@ class ExplorerClassTestCase(test.SkonfigTestCase):
         destination = os.path.join(self.remote.object_path,
                                    cdist_object.parameter_path)
         self.assertEqual(
-            sorted(glob.glob1(source, "*")),
-            sorted(glob.glob1(destination, "*")))
+            sorted(ilistdir(source, recursive=False)),
+            sorted(ilistdir(destination, recursive=False)))
 
     def test_run_type_explorer(self):
         cdist_type = core.CdistType(self.local.type_path, '__test_type')
@@ -207,8 +208,8 @@ class ExplorerClassTestCase(test.SkonfigTestCase):
         source = self.local.global_explorer_path
         destination = self.remote.global_explorer_path
         self.assertEqual(
-            sorted(glob.glob1(source, "*")),
-            sorted(glob.glob1(destination, "*")))
+            sorted(ilistdir(source, recursive=False)),
+            sorted(ilistdir(destination, recursive=False)))
 
     def test_run_parallel_jobs(self):
         expl = explorer.Explorer(


### PR DESCRIPTION
We have to replace the `glob.glob1()` function because Python will remove it in the 3.15 release.

    DeprecationWarning: glob.glob1 is deprecated and will be removed in Python 3.15. Use glob.glob and pass a directory to its root_dir argument instead.

Since the use of `glob1()` in skonfig is limited to listing directory contents, I wrote a replacement `skonfig.util.(i)listdir()` which is also prepared to exclude unwanted file (like save files `*~`) and for recursive listing of directory contents (currently not used but still useful to have).

