### PR TITLE
Add script to compile skonfig into PYZ executable

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -1,0 +1,48 @@
+---
+name: build-dist
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          submodules: true
+      - name: Information
+        run: |
+          python3 -V
+          python3 -W ignore -m pip --disable-pip-version-check list
+          bin/skonfig -V
+      - name: Build sdist
+        run: |
+          make sdist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v7
+        with:
+          path: dist/*.tar*
+          archive: false
+      - name: Build zdist
+        run: |
+          make zdist
+      - name: Upload zdist
+        uses: actions/upload-artifact@v7
+        with:
+          path: dist/*.pyz
+          archive: false
+      - name: Build wheel
+        run: |
+          make wheel
+      - name: Upload wheel
+        uses: actions/upload-artifact@v7
+        with:
+          path: dist/*.whl
+          archive: false
+      - name: Clean
+        run: |
+          make clean

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ __pycache__/
 /MANIFEST
 /dist/
 /skonfig.egg-info/
+/skonfig*.pyz
 
 # Unit tests
 /tests/openbsd-sandbox

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ help: .FORCE
 	@echo "  build           build the skonfig source code"
 	@echo "  install         install in the system site-packages directory"
 	@echo "  install-user    install in the user site-packages directory"
+	@echo "  skonfig.pyz     generate a single file executable of skonfig for distribution"
 	@echo "  clean           clean"
 	@echo ""
 	@echo "Documentation:"
@@ -43,12 +44,24 @@ help: .FORCE
 	@echo "  unittest(*)     run unit tests"
 	@echo "  unittest-remote(*) "
 	@echo ""
+	@echo "Releasing:"
+	@echo "  sdist           build a source code tar ball for distribution"
+	@echo "  zdist           build a single-file executable for distribution"
+	@echo ""
 	@echo "(*) if the environment variable SANDBOX is set, the tests will be"
 	@echo "    executed in a sandbox (use SANDBOX=help for a list of options)."
 	@echo ""
 
 
 PYTHON = python3
+
+
+###############################################################################
+# directories
+#
+
+dist:
+	mkdir -p $@
 
 
 ###############################################################################
@@ -216,6 +229,24 @@ install: build .FORCE
 
 install-user: build .FORCE
 	$(PYTHON) setup.py install --user
+
+
+###############################################################################
+# release commands
+#
+
+MAKE_PYZ_CMD = $(PYTHON) scripts/compyle.py --compression deflate --main scripts/pyzmain.py skonfig -o
+SKONFIG_VERSION_CMD = $$(python3 -c 'print(__import__("skonfig.version").version.__guess_git_version())')
+
+sdist: dist .FORCE
+	$(PYTHON) setup.py sdist --dist-dir=dist --formats=gztar --owner=$$(id -un 0) --group=$$(id -gn 0) --prune --metadata-check
+
+# development
+skonfig.pyz: .FORCE
+	$(MAKE_PYZ_CMD) $@
+
+zdist: dist .FORCE
+	$(MAKE_PYZ_CMD) "dist/skonfig-$(SKONFIG_VERSION_CMD).pyz"
 
 
 .FORCE:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# 2022,2025 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2022,2025-2026 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig.
 #
@@ -46,6 +46,7 @@ help: .FORCE
 	@echo ""
 	@echo "Releasing:"
 	@echo "  sdist           build a source code tar ball for distribution"
+	@echo "  wheel           build a Python wheel"
 	@echo "  zdist           build a single-file executable for distribution"
 	@echo ""
 	@echo "(*) if the environment variable SANDBOX is set, the tests will be"
@@ -235,18 +236,18 @@ install-user: build .FORCE
 # release commands
 #
 
-MAKE_PYZ_CMD = $(PYTHON) scripts/compyle.py --compression deflate --main scripts/pyzmain.py skonfig -o
-SKONFIG_VERSION_CMD = $$(python3 -c 'print(__import__("skonfig.version").version.__guess_git_version())')
-
 sdist: dist .FORCE
 	$(PYTHON) setup.py sdist --dist-dir=dist --formats=gztar --owner=$$(id -un 0) --group=$$(id -gn 0) --prune --metadata-check
 
+wheel: .FORCE
+	$(PYTHON) setup.py bdist_wheel --python-tag py3 --plat-name any
+
 # development
 skonfig.pyz: .FORCE
-	$(MAKE_PYZ_CMD) $@
+	$(PYTYHON) setup.py zdist --output $@
 
 zdist: dist .FORCE
-	$(MAKE_PYZ_CMD) "dist/skonfig-$(SKONFIG_VERSION_CMD).pyz"
+	$(PYTHON) setup.py zdist
 
 
 .FORCE:

--- a/scripts/compyle.py
+++ b/scripts/compyle.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import os
+import zipfile
+
+
+def find_modules(package):
+    try:
+        names = sorted(x for x in os.listdir(package) if x[0] != ".")
+    except os.error:
+        return []
+    files = []
+    for f in names:
+        full_path = os.path.join(package, f)
+        path_prefix = os.path.join(f, "")
+        if os.path.isdir(full_path):
+            files += [(path_prefix + x) for x in find_modules(full_path)]
+    files += names
+    return [f for f in files if f[-3:] == ".py"]
+
+
+def add_package_to_zip(package, zipf):
+    pkg_name = os.path.basename(package)
+    for module in find_modules(package):
+        with open(os.path.join(package, module), "rb") as f:
+            zipf.writestr(os.path.join(pkg_name, module), f.read())
+
+
+def compile_package(packages, output_file, compression, main_module=None):
+    with open(output_file, "wb") as exe:
+        exe.write(b"#!/usr/bin/env python3\n")
+
+        with zipfile.ZipFile(exe, "a", compression=compression) as zipf:
+            for package in sorted(packages):
+                add_package_to_zip(package, zipf)
+
+            # add __main__ module and make executable
+            if main_module:
+                with open(main_module, "rb") as f:
+                    zipf.writestr("__main__.py", f.read())
+        os.fchmod(exe.fileno(), 0o755 if main_module else 0o644)
+
+
+if __name__ == "__main__":
+    zip_compressions = {k: v for (k, v) in (
+        ("store", getattr(zipfile, "ZIP_STORED", None)),
+        ("deflate", getattr(zipfile, "ZIP_DEFLATED", None)),
+        ) if v is not None}
+
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--compression",
+        dest="compression",
+        choices=list(zip_compressions.keys()),
+        default="store")
+    parser.add_argument(
+        "--main",
+        dest="main_script",
+        help="run this script when the binary is executed")
+    parser.add_argument(
+        "-o",
+        dest="output_file",
+        required=True)
+    parser.add_argument(
+        dest="packages",
+        nargs="*",
+        help="a package path to include")
+    args = parser.parse_args()
+
+    compile_package(
+        args.packages,
+        output_file=args.output_file,
+        main_module=args.main_script,
+        compression=zip_compressions[args.compression])

--- a/scripts/compyle.py
+++ b/scripts/compyle.py
@@ -26,9 +26,9 @@ def add_package_to_zip(package, zipf):
             zipf.writestr(os.path.join(pkg_name, module), f.read())
 
 
-def compile_package(packages, output_file, compression, main_module=None):
+def compile_package(packages, output_file, interpreter, compression, main_module=None):
     with open(output_file, "wb") as exe:
-        exe.write(b"#!/usr/bin/env python3\n")
+        exe.write(b"#!%s\n" % (interpreter.encode()))
 
         with zipfile.ZipFile(exe, "a", compression=compression) as zipf:
             for package in sorted(packages):
@@ -55,6 +55,10 @@ if __name__ == "__main__":
         choices=list(zip_compressions.keys()),
         default="store")
     parser.add_argument(
+        "--interpreter",
+        dest="interpreter",
+        default="/usr/bin/env python3")
+    parser.add_argument(
         "--main",
         dest="main_script",
         help="run this script when the binary is executed")
@@ -71,5 +75,6 @@ if __name__ == "__main__":
     compile_package(
         args.packages,
         output_file=args.output_file,
+        interpreter=args.interpreter,
         main_module=args.main_script,
         compression=zip_compressions[args.compression])

--- a/scripts/pyzmain.py
+++ b/scripts/pyzmain.py
@@ -1,0 +1,22 @@
+#
+# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig.
+#
+# skonfig is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig. If not, see <http://www.gnu.org/licenses/>.
+#
+
+if __name__ == "__main__":
+    import skonfig.__main__
+    skonfig.__main__.run()

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ try:
         # setuptools 38.6.0 is required for connections to PyPI.
         # cf. also _pypi_can_connect()
         log.warn("You are running an old version of setuptools: %s. "
-                    "Consider upgrading." % (setuptools.__version__))
+                 "Consider upgrading." % (setuptools.__version__))
 except ImportError:
     from distutils.core import setup
     using_setuptools = False
@@ -223,6 +223,31 @@ class skonfig_sdist(distutils.command.sdist.sdist):
         hardcode_version(version_file)
 
 
+class skonfig_zdist(distutils.cmd.Command):
+    user_options = [
+        ('executable=', 'e', "specify final destination interpreter path"),
+        ('output=', 'o', "output filename of .pyz file"),
+    ]
+
+    def initialize_options(self):
+        self.output = os.path.join("dist", self.distribution.get_fullname() + ".pyz")
+        self.executable = "/usr/bin/env python3"
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        import scripts.compyle
+        import zipfile
+
+        scripts.compyle.compile_package(
+            self.distribution.package_dir.keys(),
+            output_file=self.output,
+            interpreter=self.executable,
+            main_module="scripts/pyzmain.py",
+            compression=zipfile.ZIP_DEFLATED)
+
+
 class skonfig_clean(distutils.command.clean.clean):
     def run(self):
         ManPages.clean(self.distribution, dry_run=self.dry_run)
@@ -301,12 +326,11 @@ setup(
     data_files=data_files,
     cmdclass={
         "build": skonfig_build,
+        "build_manpages": skonfig_build_manpages,
         "build_py": skonfig_build_py,
         "sdist": skonfig_sdist,
+        "zdist": skonfig_zdist,
         "clean": skonfig_clean,
-
-        # custom commands
-        "build_manpages": skonfig_build_manpages,
     },
     classifiers=[
         "Development Status :: 6 - Mature",


### PR DESCRIPTION
This is a single file containing all skonfig modules, ready to be executed with any Python >= 3.2 interpreter installed on a system.