### PR TITLE
CI: bump versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install make python3 python3-sphinx python3-sphinx-rtd-theme
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Information

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install python3 pycodestyle shellcheck
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Information

--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -24,7 +24,7 @@ jobs:
           - graalpy-22.3.1
           - graalpy-23.1.2
           - graalpy-24.2.2
-          - graalpy-25.0.0
+          - graalpy-25.0.3
         exclude:
           - {os: "macos-14", python-version: "pypy-3.6"}
           - {os: "macos-14", python-version: "pypy-3.7"}

--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -36,9 +36,10 @@ jobs:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          pip-install: setuptools
       - name: Information
         run: |
           python3 -V

--- a/.github/workflows/test-build-required.yml
+++ b/.github/workflows/test-build-required.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/test-build-required.yml
+++ b/.github/workflows/test-build-required.yml
@@ -13,7 +13,11 @@ jobs:
         os:
           - ubuntu
           - macos
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: [
+          "3.8", "3.9",
+          "3.10", "3.11", "3.12", "3.13", "3.14", "3.15",
+          "3.13t", "3.14t", "3.15t"
+          ]
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code

--- a/.github/workflows/test-build-required.yml
+++ b/.github/workflows/test-build-required.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test-unit-optional.yml
+++ b/.github/workflows/test-unit-optional.yml
@@ -24,7 +24,7 @@ jobs:
           - graalpy-22.3.1
           - graalpy-23.1.2
           - graalpy-24.2.2
-          - graalpy-25.0.0
+          - graalpy-25.0.3
         exclude:
           - {os: "macos-14", python-version: "pypy-3.6"}
           - {os: "macos-14", python-version: "pypy-3.7"}

--- a/.github/workflows/test-unit-optional.yml
+++ b/.github/workflows/test-unit-optional.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/test-unit-optional.yml
+++ b/.github/workflows/test-unit-optional.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Information

--- a/.github/workflows/test-unit-required.yml
+++ b/.github/workflows/test-unit-required.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/test-unit-required.yml
+++ b/.github/workflows/test-unit-required.yml
@@ -13,7 +13,11 @@ jobs:
         os:
           - ubuntu
           - macos
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: [
+          "3.8", "3.9",
+          "3.10", "3.11", "3.12", "3.13", "3.14", "3.15",
+          "3.13t", "3.14t", "3.15t"
+          ]
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Check out repository code

--- a/.github/workflows/test-unit-required.yml
+++ b/.github/workflows/test-unit-required.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
- Actions:
  - `actions/checkout@v4` &rarr; `actions/checkout@v6` (fixes Node.js version warning)
  - `actions/setup-python@v5` &rarr; `actions/setup-python@v6`
- GraalPy 25.0.0 &rarr; 25.0.3
  - fix "setuptools missing" error by pip-installing setuptools
- Add CPython 3.15 (pre-release) to required tests
- Add free-threaded versions of CPython 3.13-3.15 to required tests