### PR TITLE
CI: No GraalPy 25.0.3 for macos-15-intel

### DIFF
--- a/.github/workflows/test-build-optional.yml
+++ b/.github/workflows/test-build-optional.yml
@@ -28,6 +28,7 @@ jobs:
         exclude:
           - {os: "macos-14", python-version: "pypy-3.6"}
           - {os: "macos-14", python-version: "pypy-3.7"}
+          - {os: "macos-15-intel", python-version: "graalpy-25.0.3"}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code

--- a/.github/workflows/test-unit-optional.yml
+++ b/.github/workflows/test-unit-optional.yml
@@ -28,6 +28,7 @@ jobs:
         exclude:
           - {os: "macos-14", python-version: "pypy-3.6"}
           - {os: "macos-14", python-version: "pypy-3.7"}
+          - {os: "macos-15-intel", python-version: "graalpy-25.0.3"}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code


### PR DESCRIPTION
fixup #130.

There is no GraalPy 25.0.3 available in GitHub CI for macos-15-intel.