### PR TITLE
Make argparse respect colored_output setting

### DIFF
--- a/skonfig/__main__.py
+++ b/skonfig/__main__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # 2022,2024 Ander Punnar (ander at kvlt.ee)
-# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2025-2026 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig.
 #
@@ -56,27 +56,28 @@ def _initialise_global_settings():
 
 
 def run_main():
-    import skonfig.arguments
-    (parser, arguments) = skonfig.arguments.get()
-
-    if arguments.version:
-        print("skonfig", skonfig.__version__)
-        return
-
-    if arguments.dump:
-        import skonfig.dump
-        skonfig.dump.run(arguments.host)
-        return
-
-    if not arguments.host:
-        from argparse import (ArgumentError, _)
-        e = ArgumentError(
-            None, _("the following arguments are required: %s") % ("host"))
-        parser.error(str(e))
-        sys.exit(1)
-
     try:
         settings = _initialise_global_settings()
+
+        import skonfig.arguments
+        (parser, arguments) = skonfig.arguments.get(
+            color=settings.colored_output)
+
+        if arguments.version:
+            print("skonfig", skonfig.__version__)
+            return
+
+        if arguments.dump:
+            import skonfig.dump
+            skonfig.dump.run(arguments.host)
+            return
+
+        if not arguments.host:
+            from argparse import (ArgumentError, _)
+            e = ArgumentError(
+                None, _("the following arguments are required: %s") % ("host"))
+            parser.error(str(e))
+            sys.exit(1)
 
         # configure logging
         if arguments.verbosity:

--- a/skonfig/__main__.py
+++ b/skonfig/__main__.py
@@ -55,6 +55,18 @@ def _initialise_global_settings():
     return settings
 
 
+def print_version(color):
+    import re
+
+    if color:
+        fmt = "\033[35m%s\033[0m \033[1;34m%s\033[0m\033[90m%s\033[0m"
+    else:
+        fmt = "%s %s%s"
+
+    v = re.match("([0-9.]+)(.*)", skonfig.__version__).groups()
+    print(fmt % ("skonfig", *v))
+
+
 def run_main():
     try:
         settings = _initialise_global_settings()
@@ -64,7 +76,8 @@ def run_main():
             color=settings.colored_output)
 
         if arguments.version:
-            print("skonfig", skonfig.__version__)
+            print_version(
+                color=(settings.colored_output and hasattr(parser, "color")))
             return
 
         if arguments.dump:

--- a/skonfig/arguments.py
+++ b/skonfig/arguments.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # 2022-2023 Ander Punnar (ander at kvlt.ee)
-# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2025-2026 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig.
 #
@@ -38,8 +38,10 @@ def verbosity_to_logging_level(verbosity):
     return levels_used[min(verbosity, len(levels_used)-1)]
 
 
-def get():
+def get(color=True):
     parser = argparse.ArgumentParser()
+    if hasattr(parser, "_set_color"):
+        parser._set_color(color)
     parser.add_argument(
         "-V",
         dest="version",


### PR DESCRIPTION
Starting with version 3.14, CPython has started colourizing argparse output (unasked).

To have consistent output, we would like it to respect our `colored_output` setting, however.
