### PR TITLE
Fix -V for Python 3.2

### DIFF
--- a/skonfig/__main__.py
+++ b/skonfig/__main__.py
@@ -64,7 +64,7 @@ def print_version(color):
         fmt = "%s %s%s"
 
     v = re.match("([0-9.]+)(.*)", skonfig.__version__).groups()
-    print(fmt % ("skonfig", *v))
+    print(fmt % ("skonfig", v[0], v[1]))
 
 
 def run_main():


### PR DESCRIPTION
#132 introduced a regression on Python 3.2:

    SyntaxError: can use starred expression only as assignment target